### PR TITLE
Code styles issues for ReadExecutionPlanTest.scala fixed.

### DIFF
--- a/src/main/scala/org/dama/datasynth/lang/LoadPropertyTables.scala
+++ b/src/main/scala/org/dama/datasynth/lang/LoadPropertyTables.scala
@@ -3,7 +3,6 @@ package org.dama.datasynth
 import org.dama.datasynth.executionplan.ExecutionPlan._
 import org.dama.datasynth.lang.ReadExecutionPlan
 import org.dama.datasynth.schema._
-
 import scala.reflect.runtime.universe._
 import scala.collection.mutable
 

--- a/src/main/scala/org/dama/datasynth/schema/SchemaDefinition.scala
+++ b/src/main/scala/org/dama/datasynth/schema/SchemaDefinition.scala
@@ -15,7 +15,6 @@ import scala.reflect.runtime.universe._
   *
   */
 
-
 /**
   * It builds a property generator
   * @param name Generator name.


### PR DESCRIPTION
This files still lacks of an A grade regarding to codacy because it is capturing an Exception, which is required for the Test process. Since this is a Test file, this error in the code style is not considered critical.