### PR TITLE
Runtime refactoring

### DIFF
--- a/src/main/scala/org/dama/datasynth/lang/LoadPropertyTables.scala
+++ b/src/main/scala/org/dama/datasynth/lang/LoadPropertyTables.scala
@@ -3,7 +3,6 @@ package org.dama.datasynth
 import org.dama.datasynth.executionplan.ExecutionPlan._
 import org.dama.datasynth.lang.ReadExecutionPlan
 import org.dama.datasynth.schema._
-
 import scala.reflect.runtime.universe._
 import scala.collection.mutable
 

--- a/src/main/scala/org/dama/datasynth/schema/SchemaDefinition.scala
+++ b/src/main/scala/org/dama/datasynth/schema/SchemaDefinition.scala
@@ -15,7 +15,6 @@ import scala.reflect.runtime.universe._
   *
   */
 
-
 /**
   * It builds a property generator
   * @param name Generator name.


### PR DESCRIPTION
Classes in charge of creating the runtime code have been slightly modified. We have created a RuntimeClass that represent a class created in rutime and RuntimeClasses, for indexing purposes, that represent a set of Runtime Classes. 

These classes are declared in SparkRuntime.scala and affect the code in RuntimePropertyGeneratorBuilder.scala.